### PR TITLE
fix: run release-please in manifest mode so chart bumps apply

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,9 +19,12 @@ jobs:
     name: Create Release PR
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
+      # Manifest mode prefixes per-package outputs with the package path; the
+      # root package is `.`, hence the `.--` prefix. `releases_created` is the
+      # aggregate boolean across all packages.
+      release_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs['.--tag_name'] }}
+      version: ${{ steps.release.outputs['.--version'] }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -37,23 +40,25 @@ jobs:
           # GITHUB_TOKEN doesn't trigger workflows to prevent infinite loops
           # A PAT with 'repo' scope is needed to trigger CI on release PRs
           token: ${{ secrets.GH_TOKEN }}
-          # Explicitly point at our dot-prefixed config/manifest files. The
-          # action's default config-file name is `release-please-config.json`
-          # (NO leading dot), so without this our `.release-please-config.json`
-          # was silently ignored -- the chart `extra-files` bump and custom
-          # changelog sections never applied. The default manifest-file name
-          # already has a leading dot, but we set it here for clarity.
+          # Run in MANIFEST mode: drive everything from the config + manifest
+          # files. Two critical gotchas, both learned the hard way:
+          #  1. The action's default config-file name is `release-please-config.json`
+          #     (NO leading dot), so our dot-prefixed `.release-please-config.json`
+          #     must be named explicitly or it is silently ignored.
+          #  2. Passing `release-type` (or `package-name`) as an action INPUT
+          #     forces the legacy single-package mode and makes the action ignore
+          #     `config-file`/`manifest-file` entirely -- so the chart `extra-files`
+          #     bump and custom changelog sections never apply. The release type
+          #     lives in `.release-please-config.json` (`packages["."].release-type`)
+          #     instead, so it must NOT be set here.
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
-          # Release type determines how versions are calculated
-          # 'go' type works well for Go projects with go.mod
-          release-type: go
 
       - name: Log Release Info
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
         run: |
-          echo "Release created: ${{ steps.release.outputs.tag_name }}"
-          echo "Version: ${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}"
+          echo "Release created: ${{ steps.release.outputs['.--tag_name'] }}"
+          echo "Version: ${{ steps.release.outputs['.--version'] }}"
           echo "Release PR: ${{ steps.release.outputs.pr }}"
 
   # Note: Your existing release.yml workflow will automatically trigger


### PR DESCRIPTION
## Summary

Follow-up to #234. That PR added `config-file`/`manifest-file` inputs, but the 3.0.1 release PR (#235) **still** didn't bump `Chart.yaml` and **still** used default changelog section names ("Bug Fixes" instead of our custom "🐛 Bug Fixes"). That proves the config is *still* being ignored.

Root cause: `release-please-action` has two mutually-exclusive modes. Passing **`release-type` as an action input forces the legacy single-package mode**, which **ignores `config-file`/`manifest-file` entirely**. So while #234 pointed at the right config file, the `release-type: go` input kept the action in legacy mode where that config is never read.

## Changes

- **Remove the `release-type` input** from `release-please.yml`. The release type already lives in `.release-please-config.json` (`packages["."].release-type = go`), so removing the input switches the action into true **manifest mode** — where `config-file`, `manifest-file`, `extra-files` (Chart.yaml bump), and custom changelog sections all take effect.
- **Update job outputs and the Log step** to manifest-mode output keys: path-prefixed `'.--tag_name'` / `'.--version'` and the aggregate `releases_created` boolean (legacy top-level `tag_name`/`major`/`minor`/`patch` are not populated in manifest mode).

## Effect

Once merged, release-please regenerates the 3.0.1 PR correctly — bumping `Chart.yaml` to 3.0.1 and using the custom changelog sections. Merging that PR then publishes both the 3.0.1 image and the 3.0.1 chart.

## Testing

- YAML validation: ✓ release-please.yml valid

## Related Issues

Refs #218
