### PR TITLE
fix: force generic updater for Chart.yaml so appVersion bumps and annotations persist

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -68,7 +68,10 @@
         }
       ],
       "extra-files": [
-        "charts/cert-manager-webhook-infoblox-wapi/Chart.yaml"
+        {
+          "type": "generic",
+          "path": "charts/cert-manager-webhook-infoblox-wapi/Chart.yaml"
+        }
       ]
     }
   }


### PR DESCRIPTION
## Summary

Third and final fix in the version-realignment chain (#234 → #236 → this). With release-please now in manifest mode (#236), the 3.0.1 release PR finally touched `Chart.yaml` — but incorrectly:

- `version` bumped to 3.0.1 ✓
- **`appVersion` stayed at 3.0.0** ✗ — a 3.0.1 chart referencing a 3.0.0 image, the exact drift from #218
- The `# x-release-please-version` annotations and the comment block were **stripped** ✗ — breaking all future bumps

Root cause: a plain-string `extra-files` entry for a `.yaml` file selects release-please's **GenericYaml** updater, which only updates the top-level `version` property and re-serializes the YAML (dropping comments). Confirmed against the release-please docs ("Updating arbitrary YAML files": the `version` property is updated; default updater chosen by extension).

## Change

- `.release-please-config.json`: force the **generic** updater for `Chart.yaml` (`{ "type": "generic", "path": ... }`). The generic updater does annotation-based line replacement — it updates the version on **every** line carrying `# x-release-please-version` (so both `version` and `appVersion` → release version) and **preserves** the annotations and surrounding comments.

## Effect

After merge, the regenerated 3.0.1 release PR will bump **both** `version` and `appVersion` to 3.0.1 and keep the annotations intact for future releases.

## Testing

- JSON validation: ✓ `.release-please-config.json` valid
- Verified against release-please docs (generic vs. GenericYaml updater behavior)

## Related Issues

Refs #218
